### PR TITLE
fix: lazy-start message listener to prevent rate limit exhaustion

### DIFF
--- a/src/zulipchat_mcp/tools/agents.py
+++ b/src/zulipchat_mcp/tools/agents.py
@@ -11,6 +11,7 @@ from ..config import get_client, get_config_manager
 from ..core.agent_tracker import AgentTracker
 from ..core.cache import user_cache
 from ..core.client import ZulipClientWrapper
+from ..core.service_manager import ensure_listener
 from ..utils.database_manager import DatabaseManager
 from ..utils.logging import LogContext, get_logger
 from ..utils.metrics import Timer, track_tool_call, track_tool_error
@@ -193,6 +194,7 @@ def wait_for_response(request_id: str) -> dict[str, Any]:
     with Timer("zulip_mcp_tool_duration_seconds", {"tool": "wait_for_response"}):
         track_tool_call("wait_for_response")
         try:
+            ensure_listener()
             db = DatabaseManager()
             timeout_seconds = 300
             start = time.time()
@@ -524,6 +526,7 @@ def poll_agent_events(
     with Timer("zulip_mcp_tool_duration_seconds", {"tool": "poll_agent_events"}):
         track_tool_call("poll_agent_events")
         try:
+            ensure_listener()
             db = DatabaseManager()
             events = db.get_unacked_events(limit=limit, topic_prefix=topic_prefix)
             ids = [e["id"] for e in events]
@@ -634,6 +637,7 @@ def teleport_chat(
 
             # Wait for reply if requested
             if wait_for_reply:
+                ensure_listener()
                 db = DatabaseManager()
                 start = time.time()
                 while time.time() - start < reply_timeout:

--- a/tests/tools/test_agents.py
+++ b/tests/tools/test_agents.py
@@ -24,6 +24,11 @@ from src.zulipchat_mcp.tools.agents import (
 class TestAgentTools:
     """Tests for agent tools."""
 
+    @pytest.fixture(autouse=True)
+    def mock_ensure_listener(self):
+        with patch("src.zulipchat_mcp.tools.agents.ensure_listener"):
+            yield
+
     @pytest.fixture
     def mock_db(self):
         with patch("src.zulipchat_mcp.tools.agents.DatabaseManager") as mock_db_cls:


### PR DESCRIPTION
## Summary

- The MessageListener was unconditionally started on every server boot, long-polling Zulip's `/events` endpoint every ~30s with no 429 handling. Since each MCP client spawns a separate server process, multiple instances (Claude Desktop + N Claude Code sessions) would all poll simultaneously using the same user credentials, exhausting Zulip's per-user rate limit and causing 429s in the web UI.
- The `--enable-listener` flag existed in the arg parser but was silently ignored (hardcoded to `True`).
- Now the listener is off by default and lazy-started only when an agent tool that needs it (`wait_for_response`, `poll_agent_events`, `teleport_chat` with `wait_for_reply`) is first invoked. The `--enable-listener` flag is respected for users who want always-on behavior.

## Changes

- **`core/service_manager.py`**: Module-level singleton with `init_service_manager()` and `ensure_listener()` for lazy-start. All methods are idempotent. `start()` and `_afk_watcher` now respect the `enable_listener` flag.
- **`server.py`**: Passes `args.enable_listener` instead of hardcoded `True`. Only calls `start()` when the flag is set.
- **`tools/agents.py`**: `wait_for_response`, `poll_agent_events`, and `teleport_chat` (when `wait_for_reply=True`) call `ensure_listener()` before polling.
- **`tests/tools/test_agents.py`**: `autouse` fixture mocks `ensure_listener` for all agent tool tests.

## Test plan

- [x] `uv run pytest -q -m "not slow and not integration"` — 565 passed, 1 pre-existing failure (unrelated config test)
- [x] `uv run ruff check` — clean
- [x] Import validation: `from src.zulipchat_mcp.server import main` — OK
- [ ] Manual: start server without `--enable-listener`, verify no `/events` polling in Zulip logs
- [ ] Manual: call `wait_for_response` or `poll_agent_events`, verify listener lazy-starts
- [ ] Manual: start server with `--enable-listener`, verify eager-start behavior preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)