### PR TITLE
fix: drop unused tasks=True flag that breaks tool registration

### DIFF
--- a/src/zulipchat_mcp/server.py
+++ b/src/zulipchat_mcp/server.py
@@ -136,7 +136,6 @@ def main() -> None:
             "updates, request approvals, and read steering commands from the topic owner."
         ),
         on_duplicate="warn",
-        tasks=True,
         sampling_handler=sampling_handler,
         sampling_handler_behavior="fallback",  # Use only when client doesn't support sampling
     )


### PR DESCRIPTION
b886fef added `tasks=True` to the `FastMCP(...)` constructor in `src/zulipchat_mcp/server.py`, which prevents the server from starting on FastMCP 3.x. The flag flips the per-tool default to `task=True` (`fastmcp/server/server.py:1435`), so the first `mcp.tool(...)` call trips `TaskConfig.validate_function`, which calls `require_docket(...)` and raises `ImportError: FastMCP background tasks require the 'tasks' extra`. It seems that nothing in the codebase actually uses FastMCP's task system, so removing the flag preserves behavior. If the intention was to use FastMCP tasks, then some more work is needed.

Why not add `[tasks]` to the FastMCP extra? With that declaration, registration gets one tool further along and then fails with `ValueError: 'teleport_chat' uses a sync function but has task execution enabled. Background tasks require async functions.` Most tools here are synchronous, so making `tasks=True` actually work would require converting _every_ tool to `async def` or opting in per-tool — much bigger than the flag itself implies. Maybe this was intended? If background tasks ever become a real requirement, they can be enabled per-tool on the specific async functions that need them.

Closes #10 